### PR TITLE
get_varparams_with_zip as main

### DIFF
--- a/paramvar_tools.py
+++ b/paramvar_tools.py
@@ -70,7 +70,7 @@ def get_file_prefix(input_dict, std_prefix):
     return file_prefix
 
 
-def get_varparams(input_dict, varparam_key="vary_parameters"):
+def get_varparams_nozip(input_dict, varparam_key="vary_parameters"):
     """
     Reads the "vary_parameters" input (i.e., the list of names of the
     parameters that must vary during all the simulations.)
@@ -201,6 +201,10 @@ def get_varparams_with_zip(input_dict, varparam_key="vary_parameters",
         values_list = [values_list[i] for i in range(size) if i not in i_names[1:]]
 
     return var_param_names, values_list
+
+
+# Aias to the get_varparams that supports parameter zipping.
+get_varparams = get_varparams_with_zip
 
 
 def _to_tuple(arg):

--- a/paramvar_tools.py
+++ b/paramvar_tools.py
@@ -165,7 +165,7 @@ def get_varparams_with_zip(input_dict, varparam_key="vary_parameters",
         order convention as var_param_names.
     """
     # Regularly reads the list of varying parameters and their values.
-    var_param_names, values_list = get_varparams(input_dict, varparam_key)
+    var_param_names, values_list = get_varparams_nozip(input_dict, varparam_key)
 
     # Reads gets the zip parameter entry from input dict
     # If not found, simply returns the results without any zip
@@ -205,6 +205,7 @@ def get_varparams_with_zip(input_dict, varparam_key="vary_parameters",
 
 # Aias to the get_varparams that supports parameter zipping.
 get_varparams = get_varparams_with_zip
+# get_varparams_with_zip = get_varparams
 
 
 def _to_tuple(arg):


### PR DESCRIPTION
Alias the name get_varparams to the function get_varparams_with_zip, so all projects now point to this as the main function.
The old version without zipping is kept as legacy, with the name get_varparams_nozip